### PR TITLE
add support for axisvaluenames in axis

### DIFF
--- a/Lib/designSpaceDocument/__init__.py
+++ b/Lib/designSpaceDocument/__init__.py
@@ -238,6 +238,7 @@ class AxisDescriptor(SimpleDescriptor):
         self.default = None
         self.hidden = False
         self.map = []
+        self.axisValueNames = {}
 
     def serialize(self):
         # output to a dict, used in testing
@@ -249,6 +250,7 @@ class AxisDescriptor(SimpleDescriptor):
                 default = self.default,
                 hidden = self.hidden,
                 map = self.map,
+                axisValueNames = self.axisValueNames,
             )
         return d
 
@@ -395,6 +397,15 @@ class BaseDocWriter(object):
                 mapElement.attrib['input'] = self.intOrFloat(inputValue)
                 mapElement.attrib['output'] = self.intOrFloat(outputValue)
                 axisElement.append(mapElement)
+        if axisObject.axisValueNames:
+            axisValueNamesElement = ET.Element('valuenames')
+            for value, valueName in axisObject.axisValueNames.items():
+                axisvaluename = ET.Element('valuename')
+                axisvaluename.attrib['value'] = self.intOrFloat(value)
+                axisvaluename.attrib['valuename'] = valueName
+                axisValueNamesElement.append(axisvaluename)
+            axisElement.append(axisValueNamesElement)
+
         self.root.findall('.axes')[0].append(axisElement)
 
     def _addInstance(self, instanceObject):


### PR DESCRIPTION
@LettError: Maybe this is a way to add AxisValueNames into DSD?
Only added things to the 'write' part of code.

``` xml
    <axes>
        <axis default="200" maximum="1000" minimum="0" name="Name" tag="NAME">
            <valuenames>
                <valuename value="300" valuename="Normal" />
            </valuenames>
        </axis>
    </axes>
```